### PR TITLE
Change binding from purely index binding to glGetUniformLocation

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -13,6 +13,7 @@ type TextureFilterType int32
 
 type TextureDefinition struct {
 	Path   string
+	Name   string
 	Filter TextureFilterType
 }
 

--- a/demo/compression-artifact/compression-artifact.yml
+++ b/demo/compression-artifact/compression-artifact.yml
@@ -5,5 +5,7 @@ stages:
   - fragmentShaderPath: "../demo/compression-artifact/stage1.frag"
     textures:
       - path: "../demo/compression-artifact/cyberpunk.png"
+        name: "baseTexture"
       - path: "../demo/compression-artifact/trigger.png"
+        name: "triggerTexture"
         filter: NEAREST

--- a/demo/compression-artifact/stage1.frag
+++ b/demo/compression-artifact/stage1.frag
@@ -3,10 +3,9 @@
 #extension GL_ARB_explicit_uniform_location : enable
 #extension GL_ARB_shading_language_420pack : enable
 
-layout(location = 0) uniform ivec2 viewportSize;
-layout(location = 1) in vec2 fragTexCoord;
-layout(binding = 1) uniform sampler2D baseTexture;
-layout(binding = 2) uniform sampler2D triggerTexture;
+layout(location = 0) in vec2 fragTexCoord;
+layout(binding = 1, location = 2) uniform sampler2D baseTexture;
+layout(binding = 2, location = 3) uniform sampler2D triggerTexture;
 
 layout(location = 0) out vec4 fragColor;
 

--- a/demo/crt-singlestage/crt-singlestage.frag
+++ b/demo/crt-singlestage/crt-singlestage.frag
@@ -3,10 +3,10 @@
 #extension GL_ARB_explicit_uniform_location : enable
 #extension GL_ARB_shading_language_420pack : enable
 
-layout(location = 0) uniform ivec2 outputResolution;
-layout(location = 1) in vec2 fragTexCoord;
-layout(binding = 1) uniform sampler2D inputTexture;
-layout(binding = 2) uniform sampler2D pixelTexture;
+layout(location = 0) in vec2 fragTexCoord;
+layout(location = 1) uniform ivec2 outputResolution;
+layout(binding = 0, location = 2) uniform sampler2D inputTexture;
+layout(binding = 1, location = 3) uniform sampler2D pixelTexture;
 
 layout(location = 0) out vec4 fragColor;
 

--- a/demo/crt-singlestage/crt-singlestage.yml
+++ b/demo/crt-singlestage/crt-singlestage.yml
@@ -5,4 +5,6 @@ stages:
   - fragmentShaderPath: "${script_path}/crt-singlestage.frag"
     textures:
       - path: "${source_path}"
+        name: "inputTexture"
       - path: "${script_path}/phosphor.png"
+        name: "pixelTexture"

--- a/demo/crt/demo_def.yml
+++ b/demo/crt/demo_def.yml
@@ -4,8 +4,10 @@ render:
 stages:
   - fragmentShaderPath: "../demo/crt/demo_stage1.frag"
     textures:
-      - path: "C:/Users/jacobjms/Pictures/super-mario-bros.png"
-      - path: "C:/Users/jacobjms/Pictures/phosphor.png"
+      - path: "../demo/crt-singlestage/input.png"
+        name: "baseTexture"
+      - path: "../demo/crt-singlestage/phosphor.png"
+        name: "tileTexture"
   - fragmentShaderPath: "../demo/crt/demo_stage2.frag"
   - fragmentShaderPath: "../demo/crt/demo_stage3.frag"
   - fragmentShaderPath: "../demo/crt/demo_stage4.frag"

--- a/demo/crt/demo_stage1.frag
+++ b/demo/crt/demo_stage1.frag
@@ -3,8 +3,8 @@
 #extension GL_ARB_explicit_uniform_location : enable
 #extension GL_ARB_shading_language_420pack : enable
 
-layout(location = 0) uniform ivec2 viewportSize;
-layout(location = 1) in vec2 fragTexCoord;
+layout(location = 0) in vec2 fragTexCoord;
+layout(location = 1) in vec2 viewportSize;
 layout(binding = 1) uniform sampler2D baseTexture;
 layout(binding = 2) uniform sampler2D tileTexture;
 

--- a/demo/crt/demo_stage2.frag
+++ b/demo/crt/demo_stage2.frag
@@ -3,8 +3,7 @@
 #extension GL_ARB_explicit_uniform_location : enable
 #extension GL_ARB_shading_language_420pack : enable
 
-layout(location = 0) uniform ivec2 _;
-layout(location = 1) in vec2 fragTexCoord;
+layout(location = 0) in vec2 fragTexCoord;
 layout(binding = 0) uniform sampler2D previousResult;
 
 layout(location = 0) out vec4 fragColor;

--- a/demo/crt/demo_stage3.frag
+++ b/demo/crt/demo_stage3.frag
@@ -3,8 +3,7 @@
 #extension GL_ARB_explicit_uniform_location : enable
 #extension GL_ARB_shading_language_420pack : enable
 
-layout(location = 0) uniform ivec2 _;
-layout(location = 1) in vec2 fragTexCoord;
+layout(location = 0) in vec2 fragTexCoord;
 layout(binding = 0) uniform sampler2D previousResult;
 
 layout(location = 0) out vec4 fragColor;

--- a/demo/crt/demo_stage4.frag
+++ b/demo/crt/demo_stage4.frag
@@ -3,8 +3,7 @@
 #extension GL_ARB_explicit_uniform_location : enable
 #extension GL_ARB_shading_language_420pack : enable
 
-layout(location = 0) uniform ivec2 _;
-layout(location = 1) in vec2 fragTexCoord;
+layout(location = 0) in vec2 fragTexCoord;
 layout(binding = 0) uniform sampler2D previousResult;
 
 layout(location = 0) out vec4 fragColor;

--- a/engine.go
+++ b/engine.go
@@ -155,7 +155,6 @@ func (engine *Engine) Render() error {
 
 		for bindingName, texture := range stage.textures {
 			bindingLocation := gl.GetUniformLocation(stage.program, gl.Str(bindingName+"\x00"))
-			log.Printf("binding %s location %d", bindingName, bindingLocation)
 			if bindingLocation == kGLLocationNotFound {
 				return locationNotFoundError(bindingName)
 			} else {

--- a/glslfilter-glfw/main.go
+++ b/glslfilter-glfw/main.go
@@ -65,7 +65,13 @@ func main() {
 		for _, textureDefinition := range stageDefinition.Textures {
 			textureRGBA, err := glslfilter.LoadTextureData(textureDefinition.Path)
 			util.Invariant(err)
-			textures = append(textures, glslfilter.Texture{Data: textureRGBA, Filter: int32(textureDefinition.Filter)})
+			textures = append(
+				textures,
+				glslfilter.Texture{
+					Data:        textureRGBA,
+					BindingName: textureDefinition.Name,
+					Filter:      int32(textureDefinition.Filter),
+				})
 		}
 
 		stage, err := glslfilter.NewFilterStage(fragmentShaderSource, textures)
@@ -79,7 +85,9 @@ func main() {
 
 	perfTimer.LogSplit("init")
 
-	engine.Render()
+	if err := engine.Render(); err != nil {
+		util.Invariant(err)
+	}
 	window.SwapBuffers()
 
 	perfTimer.LogSplit("render")

--- a/stage.go
+++ b/stage.go
@@ -9,17 +9,19 @@ import (
 )
 
 type Texture struct {
-	Data   *image.RGBA
-	Filter int32
+	Data        *image.RGBA
+	BindingName string
+	Filter      int32
 }
 
 type FilterStage struct {
 	program  uint32
-	textures []uint32
+	textures map[string]uint32
 }
 
 func NewFilterStage(fragmentShaderSource string, textures []Texture) (stage *FilterStage, err error) {
 	stage = new(FilterStage)
+	stage.textures = make(map[string]uint32)
 
 	stage.program, err = newProgram(fragmentShaderSource)
 	if err != nil {
@@ -32,7 +34,7 @@ func NewFilterStage(fragmentShaderSource string, textures []Texture) (stage *Fil
 
 	for _, texture := range textures {
 		textureName := createTexture(texture.Data, texture.Filter)
-		stage.textures = append(stage.textures, textureName)
+		stage.textures[texture.BindingName] = textureName
 	}
 
 	return stage, err


### PR DESCRIPTION
This allows more flexibility/clarity in binding textures from filter definitions. It also means that the "magic" uniforms like viewportSize can be omitted and don't have to be at fixed locations.

The main new requirement is the need to define the name for the texture in the definition (matching the binding in the fragment shader)